### PR TITLE
Add sticky notification option

### DIFF
--- a/gander-no-op/src/main/java/com/ashokvarma/gander/GanderInterceptor.java
+++ b/gander-no-op/src/main/java/com/ashokvarma/gander/GanderInterceptor.java
@@ -66,6 +66,8 @@ public class GanderInterceptor implements Interceptor {
 
     public GanderInterceptor redactHeader(String name) { return this; }
 
+    public GanderInterceptor setSticky(boolean sticky) { return this; }
+
     @Override
     public Response intercept(Chain chain) throws IOException {
         return chain.proceed(chain.request());

--- a/gander/src/main/java/com/ashokvarma/gander/GanderInterceptor.java
+++ b/gander/src/main/java/com/ashokvarma/gander/GanderInterceptor.java
@@ -74,6 +74,7 @@ public class GanderInterceptor implements Interceptor {
     private boolean mShowNotification;
     private long mMaxContentLength = 250000L;
     private volatile Set<String> headersToRedact = Collections.emptySet();
+    private boolean stickyNotification = false;
 
     /**
      * @param context          The current Context.
@@ -128,6 +129,11 @@ public class GanderInterceptor implements Interceptor {
         newHeadersToRedact.addAll(headersToRedact);
         newHeadersToRedact.add(name);
         headersToRedact = newHeadersToRedact;
+        return this;
+    }
+
+    public GanderInterceptor setSticky(boolean sticky) {
+        this.stickyNotification = sticky;
         return this;
     }
 

--- a/gander/src/main/java/com/ashokvarma/gander/GanderInterceptor.java
+++ b/gander/src/main/java/com/ashokvarma/gander/GanderInterceptor.java
@@ -271,7 +271,7 @@ public class GanderInterceptor implements Interceptor {
         long transactionId = mGanderDatabase.httpTransactionDao().insertTransaction(transaction);
         transaction.setId(transactionId);
         if (mShowNotification) {
-            mNotificationHelper.show(transaction);
+            mNotificationHelper.show(transaction, stickyNotification);
         }
         mRetentionManager.doMaintenance();
         return transaction;
@@ -281,7 +281,7 @@ public class GanderInterceptor implements Interceptor {
         int updatedTransactionCount = mGanderDatabase.httpTransactionDao().updateTransaction(transaction);
 
         if (mShowNotification && updatedTransactionCount > 0) {
-            mNotificationHelper.show(transaction);
+            mNotificationHelper.show(transaction, stickyNotification);
         }
     }
 

--- a/gander/src/main/java/com/ashokvarma/gander/internal/support/NotificationHelper.java
+++ b/gander/src/main/java/com/ashokvarma/gander/internal/support/NotificationHelper.java
@@ -69,7 +69,7 @@ public class NotificationHelper {
         }
     }
 
-    public synchronized void show(HttpTransaction transaction) {
+    public synchronized void show(HttpTransaction transaction, boolean stickyNotification) {
         addToBuffer(transaction);
         if (!BaseGanderActivity.isInForeground()) {
             NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext, CHANNEL_ID)
@@ -77,6 +77,7 @@ public class NotificationHelper {
                     .setLocalOnly(true)
                     .setSmallIcon(R.drawable.gander_ic_notification_white_24dp)
                     .setColor(ContextCompat.getColor(mContext, R.color.gander_colorPrimary))
+                    .setOngoing(stickyNotification)
                     .setContentTitle(mContext.getString(R.string.gander_notification_title));
             NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
 


### PR DESCRIPTION
With this PR, devs will have the option to make notification sticky, by doing:

```java
new GanderInterceptor()
       ...
       .setSticky(true / false)
       ...
```

> Question, should we add in this case an extra action to notification to dismiss it?