### PR TITLE
Fallback to destructive migration in room

### DIFF
--- a/gander/src/main/java/com/ashokvarma/gander/internal/data/GanderDatabase.java
+++ b/gander/src/main/java/com/ashokvarma/gander/internal/data/GanderDatabase.java
@@ -23,7 +23,9 @@ public abstract class GanderDatabase extends RoomDatabase {
 
     public static GanderDatabase getInstance(Context context) {
         if (GANDER_DATABASE_INSTANCE == null) {
-            GANDER_DATABASE_INSTANCE = Room.databaseBuilder(context, GanderDatabase.class, "GanderDatabase").build();
+            GANDER_DATABASE_INSTANCE = Room.databaseBuilder(context, GanderDatabase.class, "GanderDatabase")
+                    .fallbackToDestructiveMigration()
+                    .build();
         }
         return GANDER_DATABASE_INSTANCE;
     }


### PR DESCRIPTION
We have a problem with Gander in UI tests. If we run UI tests twice we get ```java.lang.IllegalStateException: attempt to re-open an already-closed object: SQLiteDatabase: (database path)```
