### PR TITLE
Add api dependencies in pom.xml

### DIFF
--- a/gander/install_lib.gradle
+++ b/gander/install_lib.gradle
@@ -39,5 +39,17 @@ install {
                 }
             }
         }
+
+        pom.withXml {
+            def dependenciesNode = asNode().appendNode('dependencies')
+
+            //Add all declared 'api' dependencies to the pom.xml
+            configurations.api.allDependencies.withType(ModuleDependency) { ModuleDependency dp ->
+                def dependencyNode = dependenciesNode.appendNode('dependency')
+                dependencyNode.appendNode('groupId', dp.group)
+                dependencyNode.appendNode('artifactId', dp.name)
+                dependencyNode.appendNode('version', dp.version)
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds all dependencies declared as `api` within the `gander` module to the respective pom.xml.

The pom.xml of the `gander-no-op` module will not be changed by that (and the api-dependency of okhttp (within the `gander-no-op` module) therefore is not added to the pom.xml).
But I guess this is fine, as this library does not make any sense without the library user (the application) itself declaring the okhttp dependency. 

Fixes https://github.com/Ashok-Varma/Gander/issues/16


